### PR TITLE
Fix missing newline / kernel warning

### DIFF
--- a/nvidiabl-models.c
+++ b/nvidiabl-models.c
@@ -13,6 +13,12 @@
  * (at your option) any later version.
  */
 
+#include <linux/version.h>
+/* ioremap on >=5.7 is equivalent to ioremap_nocache */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
+#define ioremap_nocache ioremap
+#endif
+
 #include "nvidiabl-models.h"
 
 /* Register constants */

--- a/nvidiabl-module.c
+++ b/nvidiabl-module.c
@@ -218,7 +218,8 @@ static int __init nvidiabl_init(void)
 		if (strncasecmp(bl_type, backlight_type_ids[iii].id, sizeof(bl_type)) == 0) {
 #else
  		if (strnicmp(bl_type, backlight_type_ids[iii].id, sizeof(bl_type)) == 0) {
-#endif			props.type = backlight_type_ids[iii].type;
+#endif
+			props.type = backlight_type_ids[iii].type;
 			printk(KERN_INFO "nvidiabl: backlight type is %s\n", backlight_type_ids[iii].id);
 		}
 	}


### PR DESCRIPTION
Running this module, I get the following warning. This is caused by a missing
newline in `nvidiabl-module.c`. This PR fixes it.
```
------------[ cut here ]------------
nvidia_backlight: invalid backlight type
WARNING: CPU: 3 PID: 676 at ../drivers/video/backlight/backlight.c:358 backlight>
Modules linked in: nvidiabl(O+) ip_tables x_tables ipv6 crc_ccitt autofs4 dm_cry>
CPU: 3 PID: 676 Comm: systemd-modules Tainted: P           O     4.15.4 #1-NixOS
Hardware name: Hewlett-Packard HP EliteBook 8570w/176B, BIOS 68IAV Ver. F.32 12/>
RIP: 0010:backlight_device_register+0x209/0x220
RSP: 0018:ffffa7b801edbc68 EFLAGS: 00010292
RAX: 0000000000000028 RBX: ffff8a4566cb5800 RCX: ffffffffa364b2c8
RDX: 0000000000000001 RSI: 0000000000000086 RDI: 0000000000000283
RBP: ffffa7b801edbca0 R08: 0000000000000305 R09: ffffffffa3b2ca20
R10: 00000000000000de R11: 0000000000000000 R12: ffff8a4566cb5888
R13: ffffffffc13fee56 R14: ffffffffc1400780 R15: ffffffffc14007d8
FS:  00007f99fd326640(0000) GS:ffff8a457dcc0000(0000) knlGS:0000000000000000
CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
CR2: 00007ffd415d3f28 CR3: 0000000427fde005 CR4: 00000000001606e0
Call Trace:
 nvidiabl_init+0x192/0x1000 [nvidiabl]
 ? 0xffffffffc1307000
 do_one_initcall+0x4e/0x190
 ? kobject_uevent_env+0x117/0x640
 ? _cond_resched+0x15/0x40
 ? kmem_cache_alloc_trace+0x152/0x1a0
 ? do_init_module+0x22/0x201
 do_init_module+0x5b/0x201
 load_module+0x2222/0x28d0
 ? SYSC_finit_module+0xb7/0xd0
 SYSC_finit_module+0xb7/0xd0
 do_syscall_64+0x68/0x120
 entry_SYSCALL_64_after_hwframe+0x21/0x86
RIP: 0033:0x7f99fc7ee3e9
RSP: 002b:00007ffd415d5ed8 EFLAGS: 00000246 ORIG_RAX: 0000000000000139
RAX: ffffffffffffffda RBX: 000055ffbd93da10 RCX: 00007f99fc7ee3e9
RDX: 0000000000000000 RSI: 00007f99fcac5ecd RDI: 0000000000000005
RBP: 00007f99fcac5ecd R08: 0000000000000000 R09: 000055ffbd9403d0
R10: 0000000000000005 R11: 0000000000000246 R12: 0000000000000000
R13: 000055ffbd93db70 R14: 0000000000020000 R15: 00007ffd415d6040
Code: fe ff ff 48 63 dd 4c 89 e7 e8 14 3e 0c 00 48 89 d8 5b 5d 41 5c 41 5d 41 5e>
---[ end trace 9e130b3ce9711996 ]---
```